### PR TITLE
Change CI runner to self-hosted from ubuntu-latest

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   lint-type-and-test:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     env:
       TESTCONTAINERS_RYUK_DISABLED: "false"
       TESTCONTAINERS_CHECKS_DISABLE: "false"


### PR DESCRIPTION
This pull request makes a small change to the CI workflow configuration, updating the runner environment.

* The `lint-type-and-test` job in `.github/workflows/ci-develop.yml` now runs on `self-hosted` instead of `ubuntu-latest`, which may improve performance or allow for custom environment setups.